### PR TITLE
Replace WWW::Curl::Simple with WWW::Curl::Easy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,12 +7,19 @@ jobs:
   test:
     name: ✅ Run Tests
     runs-on: ubuntu-latest
+    services:
+      httpbin:
+        image: mccutchen/go-httpbin
+        ports: [8080:8080]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: apt-get install
         run: sudo make deb-install-deps
       - run: make test
+        env:
+          HTTPBIN_URL: http://localhost:${{ job.services.httpbin.ports['8080'] }}
       - run: make coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HTTPBIN_URL: http://localhost:${{ job.services.httpbin.ports['8080'] }}

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ deb-install-deps:
       libtest-mockmodule-perl \
       libtest-nowarnings-perl \
       liburi-perl \
-      libwww-curl-simple-perl \
+      libwww-curl-perl \
       libyaml-perl \
       make \
       postgresql-client

--- a/t/request.t
+++ b/t/request.t
@@ -1,0 +1,94 @@
+#!/usr/bin/perl -w
+
+use v5.28;
+use strict;
+use warnings;
+use utf8;
+
+use Encode qw(encode_utf8);
+use HTTP::Status qw(:constants status_message);
+use JSON::PP;
+use MIME::Base64;
+use Test::More;
+use Test::NoWarnings qw(had_no_warnings);
+use Theory::Demo;
+
+BEGIN { $ENV{TERM} = "vt100" }
+
+isa_ok my $demo = Theory::Demo->new(
+    input    => -1,
+    user     => 'theory',
+    base_url => $ENV{HTTPBIN_URL} || 'https://httpbingo.org/',
+), 'Theory::Demo';
+
+my $base_head = HTTP::Headers->new;
+$base_head->authorization_basic('theory');
+$base_head->user_agent("Theory::Demo/" . Theory::Demo->VERSION);
+
+for my $tc (
+    {
+        test => "GET request",
+        meth => 'GET',
+        path => 'get',
+        code => HTTP_OK,
+        head => $base_head,
+    },
+    {
+        test => "POST request",
+        meth => 'POST',
+        path => 'post',
+        head => $base_head,
+        body => '{"id": 42, "icon": "🥑"}',
+    },
+    {
+        test => "PUT request",
+        meth => 'PUT',
+        path => 'put',
+        head => $base_head,
+        body => '{"id": 42, "icon": "🥑"}',
+    },
+    {
+        test => "PATCH request",
+        meth => 'PATCH',
+        path => 'patch',
+        head => $base_head,
+        body => '{"id": 42, "icon": "🥑"}',
+    },
+    {
+        test => "DELETE request",
+        meth => 'DELETE',
+        path => 'delete',
+        head => $base_head,
+    },
+    {
+        test => "QUERY request",
+        meth => 'QUERY',
+        path => 'anything',
+        head => $base_head,
+        body => '{"id": 42, "icon": "🥑"}',
+    },
+) {
+    subtest $tc->{test} => sub {
+        my $req_body = $tc->{body} ? encode_utf8 $tc->{body} : undef;
+        ok my $res = $demo->request(
+            $tc->{meth} => $demo->_url($tc->{path}),
+            $req_body,
+        ), $tc->{test};
+        ok +(grep { $res->code == $_ } (100, 200)),
+            "$tc->{test} should have status 100 or 200";
+        ok my $body = decode_json($res->decoded_content), "$tc->{test} decode JSON body";
+        is $body->{method}, $tc->{meth}, "$tc->{test} should have sent $tc->{meth} request";
+        ok my $head = $body->{headers}, "$tc->{test} should have sent headers";
+        for my $hn ($tc->{head}->header_field_names) {
+            is_deeply $head->{$hn}, [$tc->{head}->header($hn)],
+                "$tc->{test} should have sent $hn header";
+        }
+        if ($req_body) {
+            my $exp = 'data:application/octet-stream;base64,' . encode_base64 $req_body, '';
+            is $body->{data}, $exp, "$tc->{test} should have submitted body";
+        }
+    }
+}
+
+had_no_warnings;
+done_testing;


### PR DESCRIPTION
`Simple` only handles GET and POST requests, unfortunately, so skip it and use `Easy` directly. Add a new method, `_curl`, that creates an `Easy` with everything properly configured, including a custom user agent, basic auth headers, other headers, the request body, and CA validation. It returns the object and references to scalars into which the headers and content will be populated when it executes.

Revamp the `t/demo.t` to do basic validation that the method works, then add `t/request.t` to do live testing of its functionality. Have it rely on an environment variable for the base URL it tests against, and load the `go-httpbin` service for local, reliable testing. For whatever reason it returns 100 for requests with a body while httpbingo.org returns 200, so the test accepts either response code.